### PR TITLE
v1.7 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
++ v1.7
+    - Add different errors message from knoxss api response, `KNOXSS PoC attempt got no response from target, please retry` and `KNOXSS engine failed at some point, please retry` instead of printing `Unknown Error` and retry the scan. (default: 1)
+    - Changed the KNOXSS url from https://knoxss.me to https://knoxss.pro
+    - Add the error message from knoxss api response, `Not Allowed` instead of printing `Unknown Error`
+
 + v1.6
     - Remove `<inpu>.errors.todo` file and append the urls which encountered errors into `<input>-date-time.todo` file
     - Save the Unknown Errors in `errors.log` file for further investigation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# KNOXSSer v1.6
+# KNOXSSer v1.7
 
-**An powerful bash script for massive XSS scanning leveraging [Brute Logic's](https://brutelogic.com.br/blog/about) [KNOXSS API](https://knoxss.me)**
+**An powerful bash script for massive XSS scanning leveraging [Brute Logic's](https://brutelogic.com.br/blog/about) [KNOXSS API](https://knoxss.pro)**
 
 [![made-with-bash](https://img.shields.io/badge/Made%20with-Bash-1f425f.svg)](https://www.gnu.org/software/bash/) [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/0xPugal/KNOXSSer/graphs/commit-activity) [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) [![Latest release](https://badgen.net/github/release/0xPugal/KNOXSSer?sort=semver&label=version)](https://github.com/0xPugal/KNOXSSer/releases) [![Open Source Love svg1](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/0xPugal/KNOXSSer)
 
@@ -77,7 +77,7 @@ Options:
 + Stop the scan on `Invalid or Expired API Key` and `API rate limit exceeded` and save the urls in `<input>-date-time.todo` file
 
 ## Credits
-+ An amazing [KNOXSS](https://knoxss.me/) API by Brute Logic.
++ An amazing [KNOXSS](https://knoxss.pro) API by Brute Logic.
 + This script was inspired from the [knoxnl](https://github.com/xnl-h4ck3r/knoxnl) tool created by [xnl_h4ck3r](https://twitter.com/xnl_h4ck3r).
 
 > [!CAUTION]

--- a/knoxsser.sh
+++ b/knoxsser.sh
@@ -15,7 +15,7 @@ print_banner() {
     echo -e "${CYAN}██╔═██╗ ██║╚██╗██║██║   ██║ ██╔██╗ ╚════██║╚════██║██╔══╝  ██╔══██╗ ${NC}"
     echo -e "${CYAN}██║  ██╗██║ ╚████║╚██████╔╝██╔╝ ██╗███████║███████║███████╗██║  ██║ ${NC}"
     echo -e "${CYAN}╚═╝  ╚═╝╚═╝  ╚═══╝ ╚═════╝ ╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚═╝  ╚═╝$VERSION ${NC}"
-    echo -e "                                        Made with ${RED}<3${NC} ${BOLD}by @0xPugal    ${NC}"
+    echo -e "                                        Made with ${RED}${BOLD}<3${NC} by${BOLD} @0xPugal    ${NC}"
     echo ""
 }
 
@@ -35,7 +35,7 @@ input_type="file"
 input_file=""
 api_key="KNOXSS_API_KEY"
 output_file="xss.txt"
-VERSION="v1.6"
+VERSION="v1.7"
 silent_mode=false
 use_notify=false
 parallel_processes=3
@@ -234,7 +234,7 @@ process_url() {
                 fi
                 break
 
-            elif [[ "$error" == "target connection issues (timeout)" || "$error" == "KNOXSS can't finish scan gracefully (reason unknown)" ]]; then
+            elif [[ "$error" == "target connection issues (timeout)" || "$error" == "KNOXSS can't finish scan gracefully (reason unknown)" || "$error" == "KNOXSS engine failed at some point, please retry" || "$error" == "KNOXSS PoC attempt got no response from target, please retry" || "$error" == "Expiration time reset, please try again." ]]; then
                 retries=$((retries + 1))
                 if [[ $retries -lt $retry_count ]]; then
                     echo -e "${RED}[ ERROR ] - $line - [${error}]Retrying... (${retries}/${retry_count})${NC}"
@@ -264,13 +264,13 @@ process_url() {
                     echo "$response" | jq .
                 fi
                 break
-            
-            elif [[ "$error" == "Expiration time reset, please try again." ]]; then
-                echo -e "${RED}[ ERROR ] - $line - [Expiration time reset, please try again] ${NC} [$api_call]"
+
+            elif [[ "$error" == "not allowed" ]]; then
+                echo -e "${RED}[ ERROR ] - $line - [Not Allowed]${NC} [$api_call]"
                 echo -e "$line" >> "$todo_file"
                 if $verbose_mode; then
                     echo -e "${BOLD}Verbose response from KNOXSS API: ${NC}"
-                    echo "$reponse" | jq .
+                    echo "$response" | jq .
                 fi
                 break
 


### PR DESCRIPTION
+ Add different errors message from knoxss api response, `KNOXSS PoC attempt got no response from target, please retry` and `KNOXSS engine failed at some point, please retry` instead of printing `Unknown Error` and retry the scan. (default: 1)
+ Changed the KNOXSS url from https://knoxss.me to https://knoxss.pro
+ Add the error message from knoxss api response, `Not Allowed` instead of printing `Unknown Error`